### PR TITLE
Update `selector-list-comma-newline-after` to `always` and bump release

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = {
     'selector-pseudo-element-colon-notation': 'double',
 
     // Selector list
-    'selector-list-comma-newline-after': 'always-multi-line',
+    'selector-list-comma-newline-after': 'always',
 
     // Root rule
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-preset-behance",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Stylelint preset for Behance",
   "author": "Wei Kin Huang <weikin.huang04@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
fixes adobe-community/issues#18181

**Do:**
```
.selector-1,
.selector-2,
.selector-3 {
   font-family: "Comic Sans MS";
}
```

**Don't:**
```
.selector-1, .selector-2, .selector-3 {
  font-family: "Comic Sans MS";
}
```
